### PR TITLE
The blitzortung service will now attempt to reconnect every 8 minutes…

### DIFF
--- a/src/workers/blitzortung/blitzortung.js
+++ b/src/workers/blitzortung/blitzortung.js
@@ -22,7 +22,10 @@ function setupLightningCache() {
 
 function setupBlitzortungWebSocket() {
     //Safety check.
-    if(retryCount > 5) {
+    if(retryCount === 0 && ws !== null) {
+        logger.ERROR("A connection to blitzortung is already open!");
+        return;
+    } else if(retryCount > 5) {
         logger.ERROR("Cannot (re)conntect to blitzortung websocket!");
         return;
     }
@@ -49,7 +52,7 @@ function setupBlitzortungWebSocket() {
             payload.target = "broker";
             payload.targetFunc = "addToCache";
             payload.cacheName = "lightning";
-            payload.value = {timestamp: data.time, lat: data.lat, lon: data.lon};
+            payload.value = {timestamp: new Date(Math.floor(data.time/1000000)), lat: data.lat, lon: data.lon};
             process.send(payload);
         }
     });
@@ -101,7 +104,7 @@ function lightningDataMessageHandler(msg) {
             var strike = msg.value[i];
             var dist = getDistanceBetweenTwoLatLonPoints(oLat, oLon, strike.lat, strike.lon);
             strikes.push({
-                timestamp: new Date(Math.floor(strike.timestamp/1000000)),
+                timestamp: strike.timestamp,
                 distance: dist
             });
         }

--- a/src/workers/intervalWorker.js
+++ b/src/workers/intervalWorker.js
@@ -9,7 +9,6 @@ var logger = require("../logging/logger").makeLogger("INTERV");
 function startWorker() {
     //Set up the blitzortung service.
     setupBlitzortung();
-
     //Init buienradar image data the first time.
     refreshBuienradarImages();
 
@@ -17,7 +16,9 @@ function startWorker() {
     setInterval(function() {
         logger.INFO("Refreshing data (8 minutes elapsed)");
 
-        logger.DEBUG("Retrieving and processing buienradar images");
+        //The blitzortung websocket has a tendency of closing a lot. We will attempt a reconnection every 8 minutes.
+        //If the connection is still open, nothing happens (the blitzortung service will also try to reconnect itself a few times)
+        setupBlitzortung();
         refreshBuienradarImages();
     }, 480000 );
 


### PR DESCRIPTION
… (at the same interval the buienradar images are updated) It will only do this when the connection has closed and immediate reconnection also failed.

The lightning data will have its timestamps in a more readable format.
